### PR TITLE
Make sure currentTest exists before we try to addAttachment

### DIFF
--- a/reporter/index.js
+++ b/reporter/index.js
@@ -80,7 +80,7 @@ class CypressAllureReporter {
         Cypress.on('fail', (err) => {
             this.reporter.cyCommandsFinish();
             // add video to failed test case:
-            if (Cypress.config().video) {
+            if (Cypress.config().video && this.reporter.currentTest) {
                 this.reporter.currentTest.addAttachment(
                     `${Cypress.spec.name}.mp4`,
                     'video/mp4',


### PR DESCRIPTION
Addresses #19 by not causing Cypress to swallow error messages.