### PR TITLE
Feat/improve handle hooks and screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ Cypress.Allure.reporter.runtime.writer;
 See [cypress-allure-plugin-example](https://github.com/Shelex/cypress-allure-plugin-example) project, which is already configured to use this plugin, hosting report as github page and run by github action. It has configuration for basic allure history saving (just having numbers and statuses in trends and history).  
 For complete history (allure can display 20 build results ) with links to older reports and links to CI builds check [cypress-allure-historical-example](https://github.com/Shelex/cypress-allure-historical-example) with basic and straightforward idea how to achieve it.
 
+There are also existing solutions that may help you prepare your report infrastructure:
+
+-   [Allure Server](https://github.com/kochetkov-ma/allure-server) - self-hosted portal with your reports
+-   [Github Action](https://github.com/simple-elf/allure-report-action) - report generation + better implementation for historic reports described above
+-   [Allure TestOps](https://docs.qameta.io/allure-testops/) - Allure portal for those who want more than report
+
 ## How to open report
 
 Assuming allure is already installed:
@@ -207,11 +213,14 @@ Allure API available:
 -   suite(name: string)
 -   label(name: LabelName, value: string)
 -   parameter(name: string, value: string)
+-   testParameter(name: string, value: string)
 -   link(url: string, name?: string, type?: LinkType)
 -   issue(name: string, url: string)
 -   tms(name: string, url: string)
 -   description(markdown: string)
+-   testDescription(markdown: string)
 -   descriptionHtml(html: string)
+-   testDescriptionHtml(html: string)
 -   owner(owner: string)
 -   severity(severity: Severity)
 -   tag(tag: string)
@@ -220,8 +229,6 @@ Allure API available:
 -   startStep(name: string)
 -   endStep()
 -   step(name: string, isParent: boolean)
-
-It may be assumed that Allure API method used in hooks (before/after all/each) would be applied to all/each test, but actually it is dealing with current allure executable (current test or hook) and obviously will not work. In case you need such behaviour it is better to try `test:before:run` or `test:after:run` cypress events to do so, when Allure interface commands will be applied to current test.
 
 ## VS Code for cypress + cucumber
 
@@ -237,7 +244,7 @@ In case you are using VS Code and [Cypress Helper](https://marketplace.visualstu
 
 ## Screenshots and Videos
 
-Screenshots are attached automatically, for other type of content use `testAttachment` (for current test) or `attachment` (for current executable).  
+Screenshots are attached automatically, for other type of content feel free to use `testAttachment` (for current test), `attachment` (for current executable), `attachFile` (for existing file).  
 Videos are attached for failed tests only from path specified in cypress config `videosFolder` and in case you have not passed video=false to Cypress configuration.
 Please take into account, that in case spec files have same name, cypress is trying to create subfolders in videos folder, and it is not handled from plugin unfortunately, so video may not have correct path in such edge case.
 

--- a/cypress/integration/basic/allure.spec.js
+++ b/cypress/integration/basic/allure.spec.js
@@ -1,4 +1,12 @@
-context('Allure API Context', () => {
+before(() => {
+    cy.log('This will run before scenarios');
+});
+
+after(() => {
+    cy.log('This will run after scenarios');
+});
+
+describe('Allure API Context', () => {
     beforeEach(() => {
         cy.log('This will run before every scenario');
     });

--- a/cypress/integration/cucumber/allure/hooks.js
+++ b/cypress/integration/cucumber/allure/hooks.js
@@ -1,3 +1,11 @@
+before(() => {
+    cy.log('This will run before scenarios');
+});
+
+after(() => {
+    cy.log('This will run after scenarios');
+});
+
 beforeEach(() => {
     cy.log('This will run before every scenario');
 });

--- a/reporter/afterHook.js
+++ b/reporter/afterHook.js
@@ -1,7 +1,0 @@
-/**
- * Execute task to write allure results to fs
- */
-after(() => {
-    Cypress.env('allure') &&
-        cy.task('writeAllureResults', Cypress.Allure.reporter.runtime.config);
-});

--- a/reporter/commands.js
+++ b/reporter/commands.js
@@ -13,6 +13,15 @@ Cypress.Commands.add(
     }
 );
 
+Cypress.Commands.add(
+    'testParameter',
+    { prevSubject: true },
+    (allure, name, value) => {
+        allure.testParameter(name, value);
+        cy.wrap(allure, { log: false });
+    }
+);
+
 Cypress.Commands.add('severity', { prevSubject: true }, (allure, level) => {
     allure.severity(level);
     cy.wrap(allure, { log: false });
@@ -37,6 +46,15 @@ Cypress.Commands.add(
     { prevSubject: true },
     (allure, name, content, type) => {
         allure.attachment(name, content, type);
+        cy.wrap(allure, { log: false });
+    }
+);
+
+Cypress.Commands.add(
+    'attachFile',
+    { prevSubject: true },
+    (allure, name, path, type) => {
+        allure.attachFile(name, path, type);
         cy.wrap(allure, { log: false });
     }
 );
@@ -113,6 +131,22 @@ Cypress.Commands.add(
     { prevSubject: true },
     (allure, html) => {
         allure.descriptionHtml(html);
+        cy.wrap(allure, { log: false });
+    }
+);
+Cypress.Commands.add(
+    'testDescription',
+    { prevSubject: true },
+    (allure, markdown) => {
+        allure.testDescription(markdown);
+        cy.wrap(allure, { log: false });
+    }
+);
+Cypress.Commands.add(
+    'testDescriptionHtml',
+    { prevSubject: true },
+    (allure, html) => {
+        allure.testDescriptionHtml(html);
         cy.wrap(allure, { log: false });
     }
 );

--- a/reporter/index.d.ts
+++ b/reporter/index.d.ts
@@ -32,7 +32,8 @@ type ContentType =
     | 'application/json'
     | 'video/webm'
     | 'video/mp4'
-    | 'image/jpeg';
+    | 'image/jpeg'
+    | 'application/pdf';
 type Status = 'failed' | 'broken' | 'passed' | 'skipped';
 type Severity = 'blocker' | 'critical' | 'normal' | 'minor' | 'trivial';
 
@@ -84,11 +85,17 @@ declare global {
              */
             label(name: LabelName, value: string): Allure;
             /**
-             * Add Parameter
+             * Add Parameter for current executable (step/test)
              * @param name
              * @param value
              */
             parameter(name: string, value: string): Allure;
+            /**
+             * Add Parameter for current test
+             * @param name
+             * @param value
+             */
+            testParameter(name: string, value: string): Allure;
             /**
              * Add customized link
              * @param {string} url
@@ -109,15 +116,25 @@ declare global {
              */
             tms(name: string, url: string): Allure;
             /**
-             * Add test description in markdown format
+             * Add test description in markdown format for step/test
              * @param markdown
              */
             description(markdown: string): Allure;
             /**
-             * Add test description in html format
+             * Add test description in html format for step/test
              * @param html
              */
             descriptionHtml(html: string): Allure;
+            /**
+             * Add test description in markdown format for test
+             * @param markdown
+             */
+            testDescription(markdown: string): Allure;
+            /**
+             * Add test description in html format for test
+             * @param html
+             */
+            testDescriptionHtml(html: string): Allure;
             /**
              * Add test owner
              * @param owner
@@ -169,6 +186,17 @@ declare global {
             testAttachment(
                 name: string,
                 content: Buffer | string,
+                type: ContentType
+            ): Allure;
+            /**
+             * Attach existing file to current test
+             * @param name
+             * @param path
+             * @param type
+             */
+            attachFile(
+                name: string,
+                path: string,
                 type: ContentType
             ): Allure;
             /**

--- a/reporter/stubbedAllure.js
+++ b/reporter/stubbedAllure.js
@@ -33,6 +33,10 @@ const stubbedAllure = {
     step: () => {},
     startStep: () => {},
     stepStart: () => {},
+    stepEnd: () => {},
     endStep: () => {},
-    stepEnd: () => {}
+    attachFile: () => {},
+    testDescription: () => {},
+    testDescriptionHtml: () => {},
+    testParameter: () => {}
 };

--- a/writer.js
+++ b/writer.js
@@ -67,30 +67,24 @@ function allureWriter(on, config) {
             } finally {
                 return null;
             }
-        }
-    });
-    on('after:screenshot', (details) => {
-        const resultsDir = process.env.allureResultsPath;
+        },
+        copyFileToAllure: (filePath) => {
+            const resultsDir = process.env.allureResultsPath;
+            if (process.env.allure === 'true') {
+                !fs.existsSync(resultsDir) &&
+                    fs.mkdirSync(resultsDir, { recursive: true });
+                const ext = path.extname(filePath);
+                const allurePath = path.join(
+                    resultsDir,
+                    `${uuid.v4()}-attachment${ext}`
+                );
 
-        // As after:screenshot is an event when screenshot file is saved
-        // sometimes (when saving was after test finished)
-        // we cannot access Cypress or Cypress.Allure context here
+                fs.copyFileSync(filePath, allurePath);
 
-        if (process.env.allure === 'true') {
-            !fs.existsSync(resultsDir) &&
-                fs.mkdirSync(resultsDir, { recursive: true });
-            const allurePath = path.join(
-                resultsDir,
-                `${uuid.v4()}-attachment.png`
-            );
-            return new Promise((resolve, reject) => {
-                fs.copyFile(details.path, allurePath, (err) => {
-                    if (err) {
-                        return reject(err);
-                    }
-                    resolve({ path: allurePath });
-                });
-            });
+                return fs.existsSync(allurePath)
+                    ? path.basename(allurePath)
+                    : null;
+            }
         }
     });
 }


### PR DESCRIPTION
address #28, #26, #20, #17 

- before all and after all hooks as "Set up" and "Tear down" blocks
- before each and after each as steps inside current test
- write allure results when global suite had finished, instead of after hook
- copy screenshots with task and explicitly returning allure results attachment filename instead of rewriting cypress object and guessing that no error will occur
- handle skipped tests properly