### PR TITLE
feat: retries support in Allure Report

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,6 +42,7 @@ jobs:
             - name: Testing
               run: |
                   npm run test:prepare:basic
+                  npm run test:prepare:retries
                   npm run test:prepare:cucumber
                   npm run test
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
+/.idea
 node_modules
 cypress/screenshots
 cypress/videos
 cypress/fixtures/*
-allure-results
+/allure-results
+/allure-report

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -38,7 +38,7 @@ module.exports = defineConfig({
                 readAllureResults: () => {
                     try {
                         const dir = 'cypress/fixtures';
-                        const subdirs = ['basic', 'cucumber'];
+                        const subdirs = ['basic', 'cucumber', 'retries'];
                         return subdirs.reduce((dirMap, subdir) => {
                             const dirFiles = fs.readdirSync(
                                 path.join(dir, subdir)

--- a/cypress/e2e/basic/retries.cy.js
+++ b/cypress/e2e/basic/retries.cy.js
@@ -13,6 +13,7 @@ describe('Allure Retry', () => {
         cy.visit('mytest.com');
         cy.get('body').screenshot('test-retry-screenshot');
         cy.allure().attachment('someFile.txt', 'data', 'text/plain');
+        // eslint-disable-next-line no-invalid-this
         if (this.test._currentRetry < this.test.retries()) {
             cy.wrap('Fail during test with retry').then((t) => {
                 throw new Error(t);
@@ -33,6 +34,7 @@ describe('Allure Retry', () => {
             cy.visit('mytest.com');
             cy.get('body').screenshot('test-retry-screenshot');
 
+            // eslint-disable-next-line no-invalid-this
             if (this.test._currentRetry < this.test.retries()) {
                 cy.wrap('Fail during test with retry').then((t) => {
                     throw new Error(t);

--- a/cypress/e2e/results/retries.cy.js
+++ b/cypress/e2e/results/retries.cy.js
@@ -1,0 +1,45 @@
+let results;
+
+before(() => {
+    cy.task('readAllureResults').then((r) => {
+        results = r.retries;
+    });
+});
+
+describe('Allure retries', () => {
+    const testByStatus = (status) =>
+        results.tests.filter((test) => test.status === status);
+
+    it('should have one suite', () => {
+        expect(results.suites).to.have.length(1);
+    });
+
+    it('should have test results', () => {
+        expect(results.tests).to.have.length(11);
+    });
+
+    it('should have set of unique tests and retries', () => {
+        const testNames = results.tests.map((test) => test.name);
+        const uniqueNames = Array.from(new Set(testNames));
+        expect(uniqueNames).to.have.length(5);
+    });
+
+    it('should have attachments', () => {
+        expect(results.attachments).to.have.length(25);
+    });
+
+    it('should have failed tests', () => {
+        expect(testByStatus('failed')).to.have.length(8);
+    });
+
+    it('should have other tests as passed', () => {
+        expect(testByStatus('passed')).to.have.length(3);
+    });
+
+    it('should have attachments included into tests', () => {
+        const testAttachments = results.tests
+            .map((test) => test.attachments.length)
+            .reduce((a, b) => a + b, 0);
+        expect(results.attachments).to.have.length(testAttachments);
+    });
+});

--- a/cypress/e2e/results/retry.cy.js
+++ b/cypress/e2e/results/retry.cy.js
@@ -1,25 +1,78 @@
 describe('Allure Retry', () => {
-  let attept = 0;
-  
-  it('Test with Retries', { retries: 2 }, () => {
-    attept++;
-    cy.intercept('mytest.com', { body: `
+    const html = `
     <html>
     <head></head>
     <body>
         <div>Testing text</div>
     </body>
     </html>
-    `});
-    
-    cy.visit('mytest.com');
-  
-    cy.get('body').screenshot('test-retry-screenshot');
-  
-    if (attept < 3) {
-      cy.wrap('Fail during test with retry').then(t => {
-        throw new Error(t);
-      });
-    }
-  })
+    `;
+
+    it('Test with Retries', { retries: 2 }, function () {
+        cy.intercept('mytest.com', { body: html });
+        cy.visit('mytest.com');
+        cy.get('body').screenshot('test-retry-screenshot');
+        cy.allure().attachment('someFile.txt', 'data', 'text/plain');
+        if (this.test._currentRetry < this.test.retries()) {
+            cy.wrap('Fail during test with retry').then((t) => {
+                throw new Error(t);
+            });
+        }
+    });
+
+    it(
+        'Test with Retries (no screenshots for retries)',
+        {
+            retries: 2,
+            env: {
+                allureOmitPreviousAttemptScreenshots: true
+            }
+        },
+        function () {
+            cy.intercept('mytest.com', { body: html });
+            cy.visit('mytest.com');
+            cy.get('body').screenshot('test-retry-screenshot');
+
+            if (this.test._currentRetry < this.test.retries()) {
+                cy.wrap('Fail during test with retry').then((t) => {
+                    throw new Error(t);
+                });
+            }
+        }
+    );
+
+    it(
+        'Test with Retries - fail (no screenshots for retries)',
+        {
+            retries: 2,
+            env: {
+                allureOmitPreviousAttemptScreenshots: true
+            }
+        },
+        function () {
+            cy.intercept('mytest.com', { body: html });
+            cy.visit('mytest.com');
+            cy.get('body').screenshot('test-retry-screenshot');
+
+            cy.allure().attachment('someFile.txt', 'data', 'text/plain');
+            cy.wrap('Fail during test with retry').then((t) => {
+                throw new Error(t);
+            });
+        }
+    );
+
+    it('passed Test no Retries', () => {
+        cy.intercept('mytest.com', { body: html });
+        cy.visit('mytest.com');
+        cy.get('body').screenshot('test-screenshot');
+    });
+
+    it('Failed Test no Retries', function () {
+        cy.intercept('mytest.com', { body: html });
+        cy.visit('mytest.com');
+        cy.get('body').screenshot('test-screenshot');
+        cy.wrap('Fail during test with retry').then((t) => {
+            throw new Error(t);
+        });
+    });
 });

--- a/cypress/e2e/results/retry.cy.js
+++ b/cypress/e2e/results/retry.cy.js
@@ -1,0 +1,25 @@
+describe('Allure Retry', () => {
+  let attept = 0;
+  
+  it('Test with Retries', { retries: 2 }, () => {
+    attept++;
+    cy.intercept('mytest.com', { body: `
+    <html>
+    <head></head>
+    <body>
+        <div>Testing text</div>
+    </body>
+    </html>
+    `});
+    
+    cy.visit('mytest.com');
+  
+    cy.get('body').screenshot('test-retry-screenshot');
+  
+    if (attept < 3) {
+      cy.wrap('Fail during test with retry').then(t => {
+        throw new Error(t);
+      });
+    }
+  })
+});

--- a/cypress/scripts/runner.js
+++ b/cypress/scripts/runner.js
@@ -18,7 +18,10 @@ const config = (mode) => {
             excludeSpecPattern: '*.js'
         },
         basic: {
-            specPattern: 'cypress/e2e/basic/*.cy.*'
+            specPattern: 'cypress/e2e/basic/allure.cy.*'
+        },
+        retries: {
+            specPattern: 'cypress/e2e/basic/retries.cy.*'
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "test": "npx cypress run --config specPattern=cypress/e2e/results/*.cy.js,video=false",
         "test:debug": "npx cypress open --config specPattern=cypress/e2e/results/*.test.js,video=false",
         "test:prepare:basic": "DEBUG=allure-plugin* node cypress/scripts/runner basic",
+        "test:prepare:retries": "DEBUG=allure-plugin* node cypress/scripts/runner retries",
         "test:prepare:cucumber": "DEBUG=allure-plugin* node cypress/scripts/runner cucumber",
         "fixtures:clear": "rm -r cypress/fixtures/*",
         "lint": "npx eslint ."

--- a/reporter/allure-cypress/AllureReporter.js
+++ b/reporter/allure-cypress/AllureReporter.js
@@ -183,7 +183,18 @@ module.exports = class AllureReporter {
         this.cy.chain.clear();
         this.currentTest = this.currentSuite.startTest(test.title);
         logger.allure(`created test: %O`, this.currentTest);
-        this.mochaIdToAllure[test.id] = this.currentTest.uuid;
+
+        const itemWithAttempt = {
+            allureId: this.currentTest.uuid,
+            attempt: test._currentRetry
+        };
+
+        if (this.mochaIdToAllure[test.id]) {
+            this.mochaIdToAllure[test.id].push(itemWithAttempt);
+        } else {
+            this.mochaIdToAllure[test.id] = [itemWithAttempt];
+        }
+
         this.currentTest.fullName = test.title;
         this.currentTest.historyId = crypto
             .MD5(test.fullTitle())

--- a/reporter/index.js
+++ b/reporter/index.js
@@ -286,43 +286,48 @@ const attachVideo = (reporter, test, status) => {
 
     if (Cypress.config().video && reporter.currentTest) {
         // add video to failed test case or for passed in case addVideoOnPass is true
-        if (shouldAttach) {
-            const absoluteVideoPath = Cypress.config()
-                .videosFolder.split(config.resultsPath())
-                .pop();
-
-            const relativeVideoPath = path.isAbsolute(absoluteVideoPath)
-                ? path.join(
-                      '..',
-                      path.relative(
-                          Cypress.config().fileServerFolder,
-                          absoluteVideoPath
-                      )
-                  )
-                : absoluteVideoPath;
-
-            const fileName = `${Cypress.spec.name}.mp4`;
-
-            // avoid duplicating videos, especially for after all hook when test is passed
-            if (
-                reporter.currentTest.info.attachments.some(
-                    (attachment) => attachment.name === fileName
-                )
-            ) {
-                return;
-            }
-
-            logger.allure(
-                `attaching video %s`,
-                path.join(relativeVideoPath, fileName)
-            );
-
-            reporter.currentTest.addAttachment(
-                fileName,
-                'video/mp4',
-                path.join(relativeVideoPath, fileName)
-            );
+        if (!shouldAttach) {
+            return;
         }
+
+        const absoluteVideoPath = Cypress.config()
+            .videosFolder.split(config.resultsPath())
+            .pop();
+
+        const relativeVideoPath = path.isAbsolute(absoluteVideoPath)
+            ? path.join(
+                  '..',
+                  path.relative(
+                      Cypress.config().fileServerFolder,
+                      absoluteVideoPath
+                  )
+              )
+            : absoluteVideoPath;
+
+        const fileName = `${Cypress.spec.name}.mp4`;
+
+        // avoid duplicating videos, especially for after all hook when test is passed
+        if (
+            reporter.currentTest.info.attachments.some(
+                (attachment) => attachment.name === fileName
+            )
+        ) {
+            return;
+        }
+
+        const videoFilePath = path.join(relativeVideoPath, fileName);
+
+        if (!videoFilePath) {
+            return;
+        }
+
+        logger.allure(`attaching video %s`, videoFilePath);
+
+        reporter.currentTest.addAttachment(
+            fileName,
+            'video/mp4',
+            videoFilePath
+        );
     }
 };
 

--- a/writer/attachments.js
+++ b/writer/attachments.js
@@ -20,105 +20,130 @@ const attachScreenshotsAndVideo = (allureMapping, results, config) => {
     const shouldAddVideoOnPass = config.env.allureAddVideoOnPass === true;
 
     const needVideo = results.tests.filter((test) => {
-        const allureId = allureMapping[test.testId];
-        if (!allureId) {
+        let shouldAttachVideo = false;
+
+        const testWithRetries = allureMapping[test.testId];
+        if (!testWithRetries) {
             return false;
         }
 
-        logger.writer('going to check attachments for "%s"', allureId);
+        testWithRetries.forEach((testRetry) => {
+            const { allureId, attempt } = testRetry;
+            const currentTest = test.attempts[attempt];
 
-        const fileName = `${allureId}-result.json`;
+            logger.writer('going to check attachments for "%s"', allureId);
 
-        const testFilePath = path.join(config.env.allureResultsPath, fileName);
-
-        // check if results exist, if no - create allure file
-        const isWritten = fs.existsSync(testFilePath);
-
-        if (!isWritten) {
-            const allureTest = createTest({
-                title: test.title,
-                name: test.title.pop(),
-                uuid: allureId,
-                status: test.state,
-                error: test.displayError,
-                start: results.stats.wallClockStartedAt,
-                stop: results.stats.wallClockEndedAt
-            });
-            fs.writeFileSync(testFilePath, JSON.stringify(allureTest));
-        }
-
-        const content =
-            fs.existsSync(testFilePath) && fs.readFileSync(testFilePath);
-
-        if (!content) {
-            logger.writer('could not find file "%s"', testFilePath);
-            return false;
-        }
-
-        const allureTest = JSON.parse(content);
-
-        const screenshots = config.env.allureSkipAutomaticScreenshots
-            ? []
-            : results.screenshots.filter(
-                  (screenshot) => screenshot.testId === test.testId
-              );
-
-        screenshots.forEach((screenshot) => {
-            const allureScreenshotFileName = `${uuid.v4()}-attachment${path.extname(
-                screenshot.path
-            )}`;
-            logger.writer('going to attach screenshot to "%s"', allureId);
-            const allureScreenshotPath = path.join(
+            const fileName = `${allureId}-result.json`;
+            const testFilePath = path.join(
                 config.env.allureResultsPath,
-                allureScreenshotFileName
+                fileName
             );
+            // check if results exist, if no - create allure file
+            const isWritten = fs.existsSync(testFilePath);
+            if (!isWritten) {
+                const fallBackDate = new Date(Date.now()).toISOString();
+                const allureTest = createTest({
+                    title: test.title,
+                    name: test.title.pop(),
+                    uuid: allureId,
+                    status: currentTest.state,
+                    error: currentTest.error,
+                    start: Date.parse(
+                        currentTest.wallClockStartedAt ?? fallBackDate
+                    ),
+                    stop:
+                        Date.parse(
+                            currentTest.wallClockStartedAt ?? fallBackDate
+                        ) + (currentTest.wallClockDuration ?? 0)
+                });
+
+                fs.writeFileSync(testFilePath, JSON.stringify(allureTest));
+            }
+
+            const content =
+                fs.existsSync(testFilePath) && fs.readFileSync(testFilePath);
+
+            if (!content) {
+                logger.writer('could not find file "%s"', testFilePath);
+                return false;
+            }
+
+            const allureTest = JSON.parse(content);
+
+            const getScreenshots = () => {
+                if (config.env.allureSkipAutomaticScreenshots) {
+                    return [];
+                }
+
+                return results.screenshots.filter(
+                    (screenshot) =>
+                        screenshot.testId === test.testId &&
+                        screenshot.testAttemptIndex === attempt
+                );
+            };
+
+            const screenshots = getScreenshots();
+
+            screenshots.forEach((screenshot) => {
+                const allureScreenshotFileName = `${uuid.v4()}-attachment${path.extname(
+                    screenshot.path
+                )}`;
+                logger.writer('going to attach screenshot to "%s"', allureId);
+                const allureScreenshotPath = path.join(
+                    config.env.allureResultsPath,
+                    allureScreenshotFileName
+                );
+
+                logger.writer(
+                    'copying screenshot from "%s" to "%s"',
+                    screenshot.path,
+                    allureScreenshotPath
+                );
+                fs.copyFileSync(screenshot.path, allureScreenshotPath);
+
+                allureTest.attachments.push({
+                    name:
+                        screenshot.name ||
+                        `${results.spec.name}:${screenshot.takenAt}${
+                            screenshot.testAttemptIndex
+                                ? `:attempt-${screenshot.testAttemptIndex}`
+                                : ''
+                        }`,
+                    type: imageContentType,
+                    source: allureScreenshotFileName
+                });
+            });
+
+            shouldAttachVideo =
+                (results.video &&
+                    // attach video for not passed tests or for every in case "allureAddVideoOnPass" enabled
+                    // or for tests with retries
+                    (allureTest.status !== 'passed' || shouldAddVideoOnPass)) ||
+                (test.attempts.length > 1 &&
+                    attempt === test.attempts.length - 1);
 
             logger.writer(
-                'copying screenshot from "%s" to "%s"',
-                screenshot.path,
-                allureScreenshotPath
+                `video will ${shouldAttachVideo ? '' : 'not'} be attached`
             );
-            fs.copyFileSync(screenshot.path, allureScreenshotPath);
 
-            allureTest.attachments.push({
-                name:
-                    screenshot.name ||
-                    `${results.spec.name}:${screenshot.takenAt}${
-                        screenshot.testAttemptIndex
-                            ? `:attempt-${screenshot.testAttemptIndex}`
-                            : ''
-                    }`,
-                type: imageContentType,
-                source: allureScreenshotFileName
-            });
+            if (shouldAttachVideo) {
+                logger.writer('going to attach video for "%s"', allureId);
+                const existingVideoIndex = allureTest.attachments.findIndex(
+                    (attach) => attach.type === videoContentType
+                );
+
+                existingVideoIndex === -1
+                    ? allureTest.attachments.push({
+                          name: 'video recording',
+                          type: videoContentType,
+                          source: videoPath
+                      })
+                    : (allureTest.attachments[existingVideoIndex].source =
+                          videoPath);
+            }
+
+            fs.writeFileSync(testFilePath, JSON.stringify(allureTest));
         });
-
-        const shouldAttachVideo =
-            results.video &&
-            // attach video for not passed tests or for every in case "allureAddVideoOnPass" enabled
-            (allureTest.status !== 'passed' || shouldAddVideoOnPass);
-
-        logger.writer(
-            `video will ${shouldAttachVideo ? '' : 'not'} be attached`
-        );
-
-        if (shouldAttachVideo) {
-            logger.writer('going to attach video for "%s"', allureId);
-            const existingVideoIndex = allureTest.attachments.findIndex(
-                (attach) => attach.type === videoContentType
-            );
-
-            existingVideoIndex === -1
-                ? allureTest.attachments.push({
-                      name: 'video recording',
-                      type: videoContentType,
-                      source: videoPath
-                  })
-                : (allureTest.attachments[existingVideoIndex].source =
-                      videoPath);
-        }
-
-        fs.writeFileSync(testFilePath, JSON.stringify(allureTest));
 
         return shouldAttachVideo;
     });

--- a/writer/attachments.js
+++ b/writer/attachments.js
@@ -22,13 +22,13 @@ const attachScreenshotsAndVideo = (allureMapping, results, config) => {
     const needVideo = results.tests.filter((test) => {
         let shouldAttachVideo = false;
 
-        const testWithRetries = allureMapping[test.testId];
-        if (!testWithRetries) {
+        const testIds = allureMapping[test.testId];
+        if (!testIds) {
             return false;
         }
 
-        testWithRetries.forEach((testRetry) => {
-            const { allureId, attempt } = testRetry;
+        testIds.forEach((ids) => {
+            const { allureId, attempt } = ids;
             const currentTest = test.attempts[attempt];
 
             logger.writer('going to check attachments for "%s"', allureId);
@@ -49,12 +49,12 @@ const attachScreenshotsAndVideo = (allureMapping, results, config) => {
                     status: currentTest.state,
                     error: currentTest.error,
                     start: Date.parse(
-                        currentTest.wallClockStartedAt ?? fallBackDate
+                        currentTest.wallClockStartedAt || fallBackDate
                     ),
                     stop:
                         Date.parse(
-                            currentTest.wallClockStartedAt ?? fallBackDate
-                        ) + (currentTest.wallClockDuration ?? 0)
+                            currentTest.wallClockStartedAt || fallBackDate
+                        ) + (currentTest.wallClockDuration || 0)
                 });
 
                 fs.writeFileSync(testFilePath, JSON.stringify(allureTest));
@@ -126,7 +126,7 @@ const attachScreenshotsAndVideo = (allureMapping, results, config) => {
                 `video will ${shouldAttachVideo ? '' : 'not'} be attached`
             );
 
-            if (shouldAttachVideo) {
+            if (shouldAttachVideo && videoPath) {
                 logger.writer('going to attach video for "%s"', allureId);
                 const existingVideoIndex = allureTest.attachments.findIndex(
                     (attach) => attach.type === videoContentType
@@ -148,7 +148,7 @@ const attachScreenshotsAndVideo = (allureMapping, results, config) => {
         return shouldAttachVideo;
     });
 
-    if (needVideo.length) {
+    if (needVideo.length && videoPath) {
         logger.writer('found %d tests that require video', needVideo.length);
         const resultsPath = path.join(config.env.allureResultsPath, videoPath);
 

--- a/writer/handleCrash.js
+++ b/writer/handleCrash.js
@@ -28,11 +28,11 @@ const handleCrash = (results, config) => {
 
     suite.children.push(test.uuid);
 
-    if (results.video) {
-        const videoPath = `${uuid.v4()}-attachment${path.extname(
-            results.video
-        )}`;
+    const videoPath =
+        results.video &&
+        `${uuid.v4()}-attachment${path.extname(results.video)}`;
 
+    if (videoPath) {
         test.attachments.push({
             name: 'video recording',
             type: 'video/mp4',

--- a/writer/results.js
+++ b/writer/results.js
@@ -108,7 +108,7 @@ const writeTests = ({ tests, resultsDir, clearSkipped, allureMapping }) => {
             logger.writer('skipping test "%s"', test.name);
 
             const mochaID = Object.keys(allureMapping).find(
-                (id) => allureMapping[id] === test.uuid
+                (id) => allureMapping[id].allureId === test.uuid
             );
             if (mochaID) {
                 delete allureMapping[mochaID];


### PR DESCRIPTION
Reated to: https://github.com/Shelex/cypress-allure-plugin/issues/138

After this PR: 
### Retries filter wil be available: 

![image](https://user-images.githubusercontent.com/16957275/224756297-145d388d-5c40-4b42-87fe-50a92ab78f7b.png)
![image](https://user-images.githubusercontent.com/16957275/224757590-e103166b-7d2b-40c3-bbed-ee67c1095501.png)
### Retried tests will have video uploaded 
even when noUploadoOnPasses  (as far as there were failures)
![image](https://user-images.githubusercontent.com/16957275/224758090-01f8f82c-a0d6-454d-9bd5-1e2e1e4182c3.png)


### Retries tab will have data:
![image](https://user-images.githubusercontent.com/16957275/224756475-b28c3d6c-4718-4146-8bc9-260ee79cb300.png)

### Retry details page available: 
![image](https://user-images.githubusercontent.com/16957275/224756752-f5a42e99-ab1a-4378-a448-8dd7006a4613.png)
### Proper timeline: 
![image](https://user-images.githubusercontent.com/16957275/224756996-e455d56b-badf-4ad1-9d22-d5ed12617c69.png)

