### PR TITLE
Pull request to fix automatic screenshot issues

### DIFF
--- a/reporter/index.js
+++ b/reporter/index.js
@@ -255,7 +255,7 @@ Cypress.Screenshot.defaults({
         logger.cy(`onAfterScreenshot: %O`, details);
         if (
             config.allureEnabled() &&
-            !shouldUseAfterSpec(Cypress.config()) &&
+            shouldUseAfterSpec(Cypress.config()) &&
             !config.skipAutomaticScreenshots()
         ) {
             logger.allure(`allure enabled, attaching screenshot`);


### PR DESCRIPTION
Removed the exclamation point so that the conditions set would be taken in properly.
The negation of 'shouldUseAfterSpec' causes that if condition to always be false, therefore automatic screenshots would not happen if relying on this piece of code alone.