### PR TITLE
Fix for @testID tag handling in Scenario Outline (issue #215)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,4 +123,3 @@ Fixes: #123
 ```
 
 A tool like [Commitizen](https://github.com/commitizen/cz-cli) can be used to help with formatting commit messages.
-

--- a/cypress/e2e/cucumber/allure.feature
+++ b/cypress/e2e/cucumber/allure.feature
@@ -5,17 +5,30 @@
 Feature: AllureAPI
     I want to use allure api in cypress tests
 
-@tagForRule
-Rule: TestRule
+    @tagForRule
+    Rule: TestRule
 
-@testID("12345")
-@issue("jira","tmsLink")
-@tms("tms","tmsLink")
-@link("example","https://example.com")
-@severity("minor")
-@tagForTest
-Scenario: Cucumber tags should work
-    Given I have allure tags set for Feature
-    When  I run any test
-    Then  I should see allure api working properly
-    And   Tags from test should overwrite tags from feature
+    @testID("12345")
+    @issue("jira", "tmsLink")
+    @tms("tms", "tmsLink")
+    @link("example", "https://example.com")
+    @severity("minor")
+    @tagForTest
+    Scenario: Cucumber tags should work
+        Given I have allure tags set for Feature
+        When I run any test
+        Then I should see allure api working properly
+        And Tags from test should overwrite tags from feature
+
+
+    @testID("111|222")
+    Scenario Outline: Cucumber tags should work
+        Given I have allure tags set for Feature
+        When I run any test whit "<Value>"
+        Then I should see allure api working properly
+        And Tags from test should overwrite tags from feature
+
+        Examples:
+            | Value |
+            | 1111  |
+            | 2222  |

--- a/cypress/e2e/cucumber/allure.feature
+++ b/cypress/e2e/cucumber/allure.feature
@@ -24,7 +24,7 @@ Feature: AllureAPI
     @testID("111|222")
     Scenario Outline: Cucumber tags should work
         Given I have allure tags set for Feature
-        When I run any test whit "<Value>"
+        When I run any test with "<Value>"
         Then I should see allure api working properly
         And Tags from test should overwrite tags from feature
 

--- a/cypress/e2e/cucumber/allure/steps.cy.js
+++ b/cypress/e2e/cucumber/allure/steps.cy.js
@@ -8,6 +8,10 @@ When('I run any test', () => {
     cy.log('child command for when');
 });
 
+When('I run any test whit {string}', (value) => {
+    cy.log('child command for when ' + value);
+});
+
 Then('I should see allure api working properly', () => {
     cy.log('child command for allure api "then" step');
 });

--- a/cypress/e2e/cucumber/allure/steps.cy.js
+++ b/cypress/e2e/cucumber/allure/steps.cy.js
@@ -8,8 +8,8 @@ When('I run any test', () => {
     cy.log('child command for when');
 });
 
-When('I run any test whit {string}', (value) => {
-    cy.log('child command for when ' + value);
+When('I run any test with {string}', (value) => {
+    cy.log(`child command for when ${value}`);
 });
 
 Then('I should see allure api working properly', () => {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "@GalyRain/cypress-allure-plugin",
-    "version": "1.0.0",
+    "name": "@shelex/cypress-allure-plugin",
+    "version": "0.0.0-development",
     "description": "allure reporting plugin for cypress",
     "main": "reporter/index.js",
     "types": "reporter/index.d.ts",
     "license": "Apache-2.0",
     "author": {
-        "name": "Galy Rain",
-        "email": "GalyRaimMail@gmail.com"
+        "name": "Oleksandr Shevtsov",
+        "email": "ovr.shevtsov@gmail.com"
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/GalyRain/cypress-allure-plugin.git"
+        "url": "https://github.com/Shelex/cypress-allure-plugin.git"
     },
     "files": [
         "reporter",
@@ -19,7 +19,10 @@
         "writer.js",
         "writer.d.ts"
     ],
-    "bugs": "https://github.com/GalyRain/cypress-allure-plugin/issues",
+    "bugs": "https://github.com/Shelex/cypress-allure-plugin/issues",
+    "publishConfig": {
+        "registry": "https://registry.npmjs.org/"
+    },
     "keywords": [
         "cypress",
         "allure",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "@shelex/cypress-allure-plugin",
-    "version": "0.0.0-development",
+    "name": "@GalyRain/cypress-allure-plugin",
+    "version": "1.0.0",
     "description": "allure reporting plugin for cypress",
     "main": "reporter/index.js",
     "types": "reporter/index.d.ts",
     "license": "Apache-2.0",
     "author": {
-        "name": "Oleksandr Shevtsov",
-        "email": "ovr.shevtsov@gmail.com"
+        "name": "Galy Rain",
+        "email": "GalyRaimMail@gmail.com"
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/Shelex/cypress-allure-plugin.git"
+        "url": "https://github.com/GalyRain/cypress-allure-plugin.git"
     },
     "files": [
         "reporter",
@@ -19,10 +19,7 @@
         "writer.js",
         "writer.d.ts"
     ],
-    "bugs": "https://github.com/Shelex/cypress-allure-plugin/issues",
-    "publishConfig": {
-        "registry": "https://registry.npmjs.org/"
-    },
+    "bugs": "https://github.com/GalyRain/cypress-allure-plugin/issues",
     "keywords": [
         "cypress",
         "allure",

--- a/reporter/allure-cypress/CucumberHandler.js
+++ b/reporter/allure-cypress/CucumberHandler.js
@@ -246,7 +246,7 @@ class CucumberHandler {
                             }
                         }
                         return !match;
-                    }.bind(this)) // <- bind контекста для this.outlineExampleIndex
+                    }.bind(this)) // bind context to access this.outlineExampleIndex inside callback
                     // check for links
                     .filter(function ({ name }) {
                         const match = tagToLink.exec(name);

--- a/reporter/allure-cypress/CucumberHandler.js
+++ b/reporter/allure-cypress/CucumberHandler.js
@@ -86,7 +86,9 @@ class CucumberHandler {
             const examples = this.currentScenario.examples || [];
 
             for (const example of examples) {
-                const index = example.tableBody.findIndex((item) => item.id === exampleId);
+                const index = example.tableBody.findIndex(
+                    (item) => item.id === exampleId
+                );
                 if (index !== -1) {
                     return index;
                 }
@@ -121,14 +123,14 @@ class CucumberHandler {
             if (indexes.rule !== undefined && indexes.rule !== -1) {
                 globalThis.testState.gherkinDocument.feature.children[
                     indexes.rule
-                    ].rule.children[indexes.child].scenario.tags = newTags;
+                ].rule.children[indexes.child].scenario.tags = newTags;
                 return;
             }
 
             // set tags for scenario
             globalThis.testState.gherkinDocument.feature.children[
                 indexes.child
-                ].scenario.tags = newTags;
+            ].scenario.tags = newTags;
             return;
         }
 
@@ -155,7 +157,7 @@ class CucumberHandler {
         logger.allure(`populating gherkin links from examples table`);
 
         !this.examplesStorage.length &&
-        this.examplesStorage.push(...scenario.examples);
+            this.examplesStorage.push(...scenario.examples);
 
         const example =
             this.examplesStorage.length && this.examplesStorage.pop();
@@ -220,33 +222,38 @@ class CucumberHandler {
                 }
 
                 kind.tags
-                    .filter(function ({ name }) {
-                        const match = tagToLabel.exec(name);
-                        if (match) {
-                            const [, command, value] = match;
+                    .filter(
+                        function ({ name }) {
+                            const match = tagToLabel.exec(name);
+                            if (match) {
+                                const [, command, value] = match;
 
-                            // testID handling with outline index support
-                            if (command === 'testID') {
-                                const ids = value.split('|');
-                                const index = this.outlineExampleIndex ?? 0;
-                                const id = ids[index] || ids[0];
-                                currentTest.addLabel('AS_ID', id);
-                            } else if (['feature', 'suite'].includes(command)) {
-                                // feature and suite should be overwritten to avoid duplicates
-                                const labelIndex = currentTest.info.labels.findIndex(
-                                    (label) => label.name === command
-                                );
-                                currentTest.info.labels[labelIndex] = {
-                                    name: command,
-                                    value: value
-                                };
-                            } else {
-                                // use label name
-                                currentTest.addLabel(command, value);
+                                // testID handling with outline index support
+                                if (command === 'testID') {
+                                    const ids = value.split('|');
+                                    const index = this.outlineExampleIndex ?? 0;
+                                    const id = ids[index] || ids[0];
+                                    currentTest.addLabel('AS_ID', id);
+                                } else if (
+                                    ['feature', 'suite'].includes(command)
+                                ) {
+                                    // feature and suite should be overwritten to avoid duplicates
+                                    const labelIndex =
+                                        currentTest.info.labels.findIndex(
+                                            (label) => label.name === command
+                                        );
+                                    currentTest.info.labels[labelIndex] = {
+                                        name: command,
+                                        value: value
+                                    };
+                                } else {
+                                    // use label name
+                                    currentTest.addLabel(command, value);
+                                }
                             }
-                        }
-                        return !match;
-                    }.bind(this)) // bind context to access this.outlineExampleIndex inside callback
+                            return !match;
+                        }.bind(this) // bind context to access this.outlineExampleIndex inside callback
+                    )
                     // check for links
                     .filter(function ({ name }) {
                         const match = tagToLink.exec(name);
@@ -314,13 +321,13 @@ const findScenarioIndexes = (feature, scenarioId) => {
 
         return isRule
             ? {
-                rule: index,
-                child: matchIndex
-            }
+                  rule: index,
+                  child: matchIndex
+              }
             : {
-                rule: -1,
-                child: index
-            };
+                  rule: -1,
+                  child: index
+              };
     }, {});
 };
 

--- a/reporter/allure-cypress/CucumberHandler.js
+++ b/reporter/allure-cypress/CucumberHandler.js
@@ -121,14 +121,14 @@ class CucumberHandler {
             if (indexes.rule !== undefined && indexes.rule !== -1) {
                 globalThis.testState.gherkinDocument.feature.children[
                     indexes.rule
-                ].rule.children[indexes.child].scenario.tags = newTags;
+                    ].rule.children[indexes.child].scenario.tags = newTags;
                 return;
             }
 
             // set tags for scenario
             globalThis.testState.gherkinDocument.feature.children[
                 indexes.child
-            ].scenario.tags = newTags;
+                ].scenario.tags = newTags;
             return;
         }
 
@@ -155,7 +155,7 @@ class CucumberHandler {
         logger.allure(`populating gherkin links from examples table`);
 
         !this.examplesStorage.length &&
-            this.examplesStorage.push(...scenario.examples);
+        this.examplesStorage.push(...scenario.examples);
 
         const example =
             this.examplesStorage.length && this.examplesStorage.pop();
@@ -214,43 +214,48 @@ class CucumberHandler {
          */
 
         [this.feature, this.currentRule, this.currentScenario].forEach(
-            function (kind) {
+            (kind) => {
                 if (!kind || !kind.tags || !kind.tags.length) {
                     return;
                 }
 
                 kind.tags
-                    .filter(function ({ name }) {
+                    .filter(({ name }) => {
                         const match = tagToLabel.exec(name);
                         if (match) {
                             const [, command, value] = match;
-                            // feature and suite should be overwritten to avoid duplicates
-                            if (['feature', 'suite'].includes(command)) {
-                                const index = currentTest.info.labels.findIndex(
-                                    (label) => label.name === command
-                                );
-                                currentTest.info.labels[index] = {
+
+                            if (command === 'testID') {
+                                const ids = value.split('|');
+                                const index = this.outlineExampleIndex ?? 0;
+                                const id = ids[index] || ids[0];
+                                this.reporter.currentTest.addLabel('AS_ID', id);
+                            } else if (['feature', 'suite'].includes(command)) {
+                                const labelIndex =
+                                    this.reporter.currentTest.info.labels.findIndex(
+                                        (label) => label.name === command
+                                    );
+                                this.reporter.currentTest.info.labels[
+                                    labelIndex
+                                    ] = {
                                     name: command,
-                                    value: value
+                                    value
                                 };
                             } else {
-                                // handle renaming label for testID, or just use label name
-                                currentTest.addLabel(
-                                    command === 'testID' ? 'AS_ID' : command,
+                                this.reporter.currentTest.addLabel(
+                                    command,
                                     value
                                 );
                             }
                         }
                         return !match;
                     })
-                    // check for links
-                    .filter(function ({ name }) {
+                    .filter(({ name }) => {
                         const match = tagToLink.exec(name);
                         if (match) {
                             const [, command, name, matchUrl] = match;
 
                             const url = matchUrl || name;
-
                             const prefixBy = {
                                 issue: Cypress.env('issuePrefix'),
                                 tms: Cypress.env('tmsPrefix'),
@@ -262,7 +267,8 @@ class CucumberHandler {
                                 urlPrefix && urlPrefix.includes('*')
                                     ? urlPrefix
                                     : `${urlPrefix}*`;
-                            currentTest.addLink(
+
+                            this.reporter.currentTest.addLink(
                                 urlPrefix && pattern
                                     ? pattern.replace(/\*/g, url)
                                     : url,
@@ -272,9 +278,11 @@ class CucumberHandler {
                         }
                         return !match;
                     })
-                    // add other tags
-                    .forEach(function ({ name }) {
-                        currentTest.addLabel('tag', name.replace('@', ''));
+                    .forEach(({ name }) => {
+                        this.reporter.currentTest.addLabel(
+                            'tag',
+                            name.replace('@', '')
+                        );
                     });
             }
         );
@@ -310,13 +318,13 @@ const findScenarioIndexes = (feature, scenarioId) => {
 
         return isRule
             ? {
-                  rule: index,
-                  child: matchIndex
-              }
+                rule: index,
+                child: matchIndex
+            }
             : {
-                  rule: -1,
-                  child: index
-              };
+                rule: -1,
+                child: index
+            };
     }, {});
 };
 


### PR DESCRIPTION
This PR fixes the issue with handling `@testID("111|222")` in `Scenario Outline`.

✅ Features:
- Correctly resolves the `AS_ID` per example row
- Keeps compatibility with old and new Gherkin document formats
- Minimal changes to the original codebase
- Retains all original comments and structure

Fixes: #215